### PR TITLE
Fix default value reapplication after resets

### DIFF
--- a/index.html
+++ b/index.html
@@ -2924,6 +2924,9 @@
             settings = cloneSettings(defaultSettings);
             setActiveLegend('pain');
             localStorage.removeItem('spondylogSettings');
+            // Réinitialise également les jours ignorés pour la valeur par défaut
+            defaultSkipDates = { pain: {}, stiffness: {} };
+            localStorage.removeItem('spondylogDefaultSkipDates');
             applySettingsToUI();
         }
 
@@ -6106,6 +6109,10 @@
                     }
                     settings.defaultLevels.pain = newPain;
                     settings.defaultLevels.stiffness = newStiff;
+
+                    // Réinitialiser les jours ignorés afin que les nouvelles
+                    // valeurs par défaut puissent s'appliquer sur les cases vides
+                    defaultSkipDates = { pain: {}, stiffness: {} };
 
                     setActiveLegend('pain');
 


### PR DESCRIPTION
## Summary
- Clear skipped days when saving settings so defaults reapply to empty days only after user confirmation
- Reset skipped days when settings are reset to defaults

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/SpondyLog/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689f1919f1fc8324a55d6ecee38f8d89