### PR TITLE
Fix default symptom value application

### DIFF
--- a/defaultValues.js
+++ b/defaultValues.js
@@ -1,0 +1,65 @@
+'use strict';
+
+function getTodayId(tz, date = new Date()) {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric'
+  });
+  const parts = formatter.formatToParts(date).reduce((acc, p) => ({ ...acc, [p.type]: p.value }), {});
+  return `${parseInt(parts.year)}-${parseInt(parts.month)}-${parseInt(parts.day)}`;
+}
+
+function saveDefault(state, metric, value, now = new Date(), tz = 'UTC') {
+  state.settings.defaultLevels[metric] = value;
+  if (value > 0) {
+    const todayId = getTodayId(tz, now);
+    state.settings.defaultStartDates[metric] = todayId;
+    state.settings.defaultTimeZones[metric] = tz;
+    const data = state[metric];
+    const cur = data[todayId];
+    if (cur === undefined || cur === null || cur === 0) {
+      data[todayId] = value;
+    }
+  } else {
+    state.settings.defaultStartDates[metric] = null;
+    state.settings.defaultTimeZones[metric] = null;
+  }
+}
+
+function dailyMaterialization(state, now = new Date(), tz = 'UTC') {
+  const todayId = getTodayId(tz, now);
+  const today = todayId;
+  ['pain', 'stiffness'].forEach(metric => {
+    const level = state.settings.defaultLevels[metric];
+    const start = state.settings.defaultStartDates[metric];
+    if (level > 0 && start && start <= today) {
+      const data = state[metric];
+      const cur = data[todayId];
+      const skipped = state.defaultSkipDates[metric] && state.defaultSkipDates[metric][todayId];
+      if ((cur === undefined || cur === null || cur === 0) && !skipped) {
+        data[todayId] = level;
+      }
+    }
+  });
+}
+
+function resetDay(state, dateId, metrics = ['pain', 'stiffness']) {
+  metrics.forEach(metric => {
+    const data = state[metric];
+    delete data[dateId];
+    if (!state.defaultSkipDates[metric]) state.defaultSkipDates[metric] = {};
+    state.defaultSkipDates[metric][dateId] = true;
+  });
+}
+
+function saveManual(state, dateId, metric, value) {
+  if (value > 0) {
+    state[metric][dateId] = value;
+  } else {
+    delete state[metric][dateId];
+  }
+}
+
+module.exports = { getTodayId, saveDefault, dailyMaterialization, resetDay, saveManual };

--- a/index.html
+++ b/index.html
@@ -2478,23 +2478,22 @@
             defaultSkipDates.stiffness[dateId] = true;
         }
 
-        function applyDefaultValues() {
+        function applyDefaultValues(forceToday = false) {
             const tz = getUserTimeZone();
-            const today = parseDateId(getTodayId(tz));
-        ['pain','stiffness'].forEach(variant => {
+            const todayId = getTodayId(tz);
+            const today = parseDateId(todayId);
+            ['pain','stiffness'].forEach(variant => {
                 const level = settings.defaultLevels[variant];
                 const startStr = settings.defaultStartDates ? settings.defaultStartDates[variant] : null;
-                const skip = defaultSkipDates[variant] || {};
                 if (level > 0 && startStr) {
-                    const data = variant === 'pain' ? userPainData : userStiffnessData;
-                    let cur = parseDateId(startStr);
-                    while (cur <= today) {
-                        const id = `${cur.getFullYear()}-${cur.getMonth()+1}-${cur.getDate()}`;
-                        // Considère comme vide toute valeur nulle ou non définie
-                        if ((data[id] === undefined || data[id] === null || data[id] === 0) && !skip[id]) {
-                            data[id] = level;
+                    const start = parseDateId(startStr);
+                    if (start <= today) {
+                        const data = variant === 'pain' ? userPainData : userStiffnessData;
+                        const cur = data[todayId];
+                        const skipped = defaultSkipDates[variant] && defaultSkipDates[variant][todayId];
+                        if ((cur === undefined || cur === null || cur === 0) && (forceToday || !skipped)) {
+                            data[todayId] = level;
                         }
-                        cur.setDate(cur.getDate() + 1);
                     }
                 }
             });
@@ -6117,14 +6116,10 @@
                     settings.defaultLevels.pain = newPain;
                     settings.defaultLevels.stiffness = newStiff;
 
-                    // Réinitialise les jours ignorés pour que les nouvelles valeurs par défaut
-                    // ne s'appliquent qu'à partir du jour courant.
-                    defaultSkipDates = { pain: {}, stiffness: {} };
-
                     setActiveLegend('pain');
 
                     saveSettings();
-                    applyDefaultValues();
+                    applyDefaultValues(true);
 
                     saveUserData();
                     applySettingsToUI();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "spondylog",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/defaultValues.test.js
+++ b/tests/defaultValues.test.js
@@ -1,0 +1,110 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const { getTodayId, saveDefault, dailyMaterialization, resetDay, saveManual } = require('../defaultValues');
+
+function createState() {
+  return {
+    pain: {},
+    stiffness: {},
+    defaultSkipDates: { pain: {}, stiffness: {} },
+    settings: {
+      defaultLevels: { pain: 0, stiffness: 0 },
+      defaultStartDates: { pain: null, stiffness: null },
+      defaultTimeZones: { pain: null, stiffness: null }
+    }
+  };
+}
+
+test('S1 Auto si vide', () => {
+  const state = createState();
+  const tz = 'UTC';
+  const today = new Date('2023-08-20T10:00:00Z');
+  const id = getTodayId(tz, today);
+  saveDefault(state, 'pain', 1, today, tz);
+  assert.strictEqual(state.pain[id], 1);
+});
+
+test('S2 Reset bloque auto', () => {
+  const state = createState();
+  const tz = 'UTC';
+  const today = new Date('2023-08-20T10:00:00Z');
+  const id = getTodayId(tz, today);
+  saveDefault(state, 'pain', 1, today, tz);
+  resetDay(state, id, ['pain']);
+  dailyMaterialization(state, today, tz);
+  assert.strictEqual(state.pain[id], undefined);
+});
+
+test('S3 Revalidation explicite', () => {
+  const state = createState();
+  const tz = 'UTC';
+  const today = new Date('2023-08-20T10:00:00Z');
+  const id = getTodayId(tz, today);
+  saveDefault(state, 'pain', 1, today, tz);
+  resetDay(state, id, ['pain']);
+  dailyMaterialization(state, today, tz);
+  saveDefault(state, 'pain', 1, today, tz);
+  assert.strictEqual(state.pain[id], 1);
+});
+
+test('S4 Futur OK', () => {
+  const state = createState();
+  const tz = 'UTC';
+  const day0 = new Date('2023-08-20T10:00:00Z');
+  const day1 = new Date('2023-08-21T00:02:00Z');
+  saveDefault(state, 'pain', 1, day0, tz);
+  dailyMaterialization(state, day1, tz);
+  const id1 = getTodayId(tz, day1);
+  assert.strictEqual(state.pain[id1], 1);
+});
+
+test('S5 Pas de rétroactivité', () => {
+  const state = createState();
+  const tz = 'UTC';
+  const day15 = new Date('2023-08-15T10:00:00Z');
+  const id15 = getTodayId(tz, day15);
+  saveDefault(state, 'pain', 1, day15, tz);
+  resetDay(state, id15, ['pain']);
+  const day20 = new Date('2023-08-20T10:00:00Z');
+  const id20 = getTodayId(tz, day20);
+  saveDefault(state, 'pain', 2, day20, tz);
+  assert.strictEqual(state.pain[id15], undefined);
+  assert.strictEqual(state.pain[id20], 2);
+  const day21 = new Date('2023-08-21T00:02:00Z');
+  dailyMaterialization(state, day21, tz);
+  const id21 = getTodayId(tz, day21);
+  assert.strictEqual(state.pain[id21], 2);
+});
+
+test('S6 Manual > Default', () => {
+  const state = createState();
+  const tz = 'UTC';
+  const today = new Date('2023-08-20T10:00:00Z');
+  const id = getTodayId(tz, today);
+  saveDefault(state, 'pain', 1, today, tz);
+  saveManual(state, id, 'pain', 3);
+  dailyMaterialization(state, today, tz);
+  assert.strictEqual(state.pain[id], 3);
+});
+
+test('S7 Zéro = vide', () => {
+  const state = createState();
+  const tz = 'UTC';
+  const today = new Date('2023-08-20T10:00:00Z');
+  const id = getTodayId(tz, today);
+  saveManual(state, id, 'pain', 0);
+  assert.strictEqual(state.pain[id], undefined);
+});
+
+test('S8 Chgmt TZ', () => {
+  const state = createState();
+  const activation = new Date('2023-08-20T10:00:00Z');
+  saveDefault(state, 'pain', 1, activation, 'Europe/Paris');
+  const newZoneDate = new Date('2023-08-21T00:30:00Z');
+  dailyMaterialization(state, newZoneDate, 'America/New_York');
+  const idNY = getTodayId('America/New_York', newZoneDate);
+  const idParis = getTodayId('Europe/Paris', newZoneDate);
+  assert.strictEqual(state.pain[idNY], 1);
+  assert.strictEqual(state.pain[idParis], undefined);
+});


### PR DESCRIPTION
## Summary
- avoid retroactive default value writes and honor reset flags
- reapply default explicitly when settings saved
- add unit tests for default scheduling and reset scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b473d41883248bbfee596bec1336